### PR TITLE
Bugfix: HighlightView wasn't updated on rotation change

### DIFF
--- a/CropImage.cs
+++ b/CropImage.cs
@@ -127,6 +127,7 @@ namespace CropImage
                 bitmap = Util.rotateImage(bitmap, -90);
                 RotateBitmap rotateBitmap = new RotateBitmap(bitmap);
                 imageView.SetImageRotateBitmapResetBase(rotateBitmap, true);
+                addHighlightView();
             };
 
             FindViewById<Button>(Resource.Id.rotateRight).Click += (o, e) =>
@@ -134,6 +135,7 @@ namespace CropImage
                 bitmap = Util.rotateImage(bitmap, 90);
                 RotateBitmap rotateBitmap = new RotateBitmap(bitmap);
                 imageView.SetImageRotateBitmapResetBase(rotateBitmap, true);
+                addHighlightView();
             };
 
             imageView.SetImageBitmapResetBase(bitmap, true);


### PR DESCRIPTION
Problem:

Under certain circumstances you couldn't move the HighlightView to the edge of the image, when you have rotated the image:

Fix:

Call addHighlightView() on rotation change in order to refresh the HighlightView.
